### PR TITLE
Overall "overhaul"

### DIFF
--- a/text-objects.kak
+++ b/text-objects.kak
@@ -13,9 +13,9 @@ map global object 't'     '<esc>: text-object-tag<ret>'                -docstrin
 map global object '<tab>' '<esc>: text-object-indented-paragraph<ret>' -docstring 'indented paragraph'
 # depends on occivink/vertical-selection.kak
 map global object 'v' '<esc>: try %{
-                           text-object-vertical
+                         text-object-vertical
                        } catch %{
-                           echo -markup "{Information}occivink/vertical-selection.kak not installed"
+                         echo -markup "{Information}occivink/vertical-selection.kak not installed"
                        }
                        <ret>' -docstring 'vertical'
 # alias to avoid shift
@@ -83,12 +83,12 @@ define-command -hidden text-object-indented-paragraph %{
 define-command -hidden text-object-vertical %{
   evaluate-commands %sh{
     case "$kak_opt_last_mode" in
-      '<a-i>') k='<esc>:select-vertically<ret>' ;;
-      '<a-a>') k='<a-i>w<esc>:select-vertically<ret>' ;;
-      '[') k='<esc>:select-up<ret>' ;;
-      ']') k='<esc>:select-down<ret>' ;;
-      '{') k='<a-i>w<esc>:select-up<ret>' ;;
-      '}') k='<a-i>w<esc>:select-down<ret>' ;;
+      '<a-i>') k='<esc>: select-vertically<ret>' ;;
+      '<a-a>') k='<a-i>w<esc>: select-vertically<ret>' ;;
+      '[') k='<esc>: select-up<ret>' ;;
+      ']') k='<esc>: select-down<ret>' ;;
+      '{') k='<a-i>w<esc>: select-up<ret>' ;;
+      '}') k='<a-i>w<esc>: select-down<ret>' ;;
     esac
     [ -n "$k" ] && echo "execute-keys $k"
   }
@@ -106,23 +106,23 @@ hook global NormalKey (g|G|v|V|<a-i>|<a-a>|\[|\]|\{|\}|<a-\[>|<a-\]>|<a-\{>|<a-\
 # to add the mappings back if needed
 define-command -hidden text-object-map %{
   try %{ declare-user-mode selectors }
-  map global user s ':enter-user-mode selectors<ret>' -docstring 'selectors…'
+  map global user s ': enter-user-mode selectors<ret>' -docstring 'selectors…'
 
-  map global selectors a '*%s<ret>' -docstring 'select all'
-  map global selectors b '%'        -docstring 'select buffer %'
+  map global selectors 'a' '*%s<ret>' -docstring 'select all'
+  map global selectors 'b' '%'        -docstring 'select buffer %'
 
-  map global selectors i <a-i> -docstring 'select inside object <a-i>'
-  map global selectors o <a-a> -docstring 'select outside object <a-a>'
+  map global selectors 'i' '<a-i>' -docstring 'select inside object <a-i>'
+  map global selectors 'o' '<a-a>' -docstring 'select outside object <a-a>'
 
-  map global selectors j <a-[> -docstring 'select inner object start <a-[>'
-  map global selectors k <a-]> -docstring 'select inner object end <a-]>'
-  map global selectors J <a-{> -docstring 'extend inner object start <a-{>'
-  map global selectors K <a-}> -docstring 'extend inner object end <a-}>'
+  map global selectors 'j' '<a-[>' -docstring 'select inner object start <a-[>'
+  map global selectors 'k' '<a-]>' -docstring 'select inner object end <a-]>'
+  map global selectors 'J' '<a-{>' -docstring 'extend inner object start <a-{>'
+  map global selectors 'K' '<a-}>' -docstring 'extend inner object end <a-}>'
 
-  map global selectors h [ -docstring 'select object start ['
-  map global selectors l ] -docstring 'select object end ]'
-  map global selectors H { -docstring 'extend object start {'
-  map global selectors L } -docstring 'extend object end }'
+  map global selectors 'h' '[' -docstring 'select object start ['
+  map global selectors 'l' ']' -docstring 'select object end ]'
+  map global selectors 'H' '{' -docstring 'extend object start {'
+  map global selectors 'L' '}' -docstring 'extend object end }'
 }
 
 # in rare scenarios when you need the original mappings

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -11,13 +11,9 @@ map global object '<gt>' '<esc>: text-object-block <gt><ret>' -docstring 'next a
 map global object 'x'     '<esc>: text-object-line<ret>'               -docstring 'line'
 map global object 't'     '<esc>: text-object-tag<ret>'                -docstring 'tag'
 map global object '<tab>' '<esc>: text-object-indented-paragraph<ret>' -docstring 'indented paragraph'
-# depends on occivink/vertical-selection.kak
-map global object 'v' '<esc>: try %{
-                         text-object-vertical
-                       } catch %{
-                         echo -markup "{Information}occivink/vertical-selection.kak not installed"
-                       }
-                       <ret>' -docstring 'vertical'
+# depends on occivink/kakoune-vertical-selection
+map global object 'v' '<esc>: text-object-vertical<ret>'
+
 # alias to avoid shift
 map global object 'd' '"' -docstring 'double quote string'
 map global object 'o' 'B' -docstring 'braces'
@@ -79,18 +75,22 @@ define-command -hidden text-object-indented-paragraph %{
   execute-keys '<a-i>i<a-z>i'
 }
 
-# depends on occivink/vertical-selection.kak
+# depends on occivink/kakoune-vertical-selection
 define-command -hidden text-object-vertical %{
-  evaluate-commands %sh{
-    case "$kak_opt_objects_last_mode" in
-      '<a-i>') k='<esc>:<space>select-vertically<ret>' ;;
-      '<a-a>') k='<a-i>w<esc>:<space>select-vertically<ret>' ;;
-      '[') k='<esc>:<space>select-up<ret>' ;;
-      ']') k='<esc>:<space>select-down<ret>' ;;
-      '{') k='<a-i>w<esc>:<space>select-up<ret>' ;;
-      '}') k='<a-i>w<esc>:<space>select-down<ret>' ;;
-    esac
-    [ -n "$k" ] && echo "execute-keys $k"
+  try %{
+    evaluate-commands %sh{
+      case "$kak_opt_objects_last_mode" in
+        '<a-i>') k='<esc>:<space>select-vertically<ret>' ;;
+        '<a-a>') k='<a-i>w<esc>:<space>select-vertically<ret>' ;;
+        '[') k='<esc>:<space>select-up<ret>' ;;
+        ']') k='<esc>:<space>select-down<ret>' ;;
+        '{') k='<a-i>w<esc>:<space>select-up<ret>' ;;
+        '}') k='<a-i>w<esc>:<space>select-down<ret>' ;;
+      esac
+      [ -n "$k" ] && echo "execute-keys $k"
+    }
+  } catch %{
+    fail "no selections remaining" 
   }
 }
 

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -38,7 +38,7 @@ define-command -hidden text-object-block -params 1 %@
       '>') t='<';dir='/'; ;;
     esac
     # $t is used instead of $1 to provide more 'intuitive' prev / next blocks when nested
-    echo "try %| exec $kak_opt_last_mode '$t' | catch %| exec $dir \Q '$t' \E <ret> ; exec $kak_opt_last_mode '$t' |"
+    echo "try %| exec $kak_opt_objects_last_mode '$t' | catch %| exec $dir \Q '$t' \E <ret> ; exec $kak_opt_objects_last_mode '$t' |"
   !
 @
 
@@ -46,7 +46,7 @@ define-command -hidden text-object-block -params 1 %@
 # it is mostly here to improve the orthogonality of kakoune design
 define-command -hidden text-object-line %{
   evaluate-commands %sh{
-    case "$kak_opt_last_mode" in
+    case "$kak_opt_objects_last_mode" in
       '<a-i>') k='x_' ;;
       '<a-a>') k='x' ;;
       '[') k='<a-h>' ;;
@@ -65,7 +65,7 @@ define-command -hidden text-object-line %{
 # work in progress - very brittle for now
 define-command -hidden text-object-tag %{
   evaluate-commands %sh{
-    case "$kak_opt_last_mode" in
+    case "$kak_opt_objects_last_mode" in
       '<a-i>') k='<a-i>c<gt>,<lt><ret>' ;;
       '<a-a>') k='<esc><a-f><lt>2f<gt>' ;;
     esac
@@ -82,7 +82,7 @@ define-command -hidden text-object-indented-paragraph %{
 # depends on occivink/vertical-selection.kak
 define-command -hidden text-object-vertical %{
   evaluate-commands %sh{
-    case "$kak_opt_last_mode" in
+    case "$kak_opt_objects_last_mode" in
       '<a-i>') k='<esc>: select-vertically<ret>' ;;
       '<a-a>') k='<a-i>w<esc>: select-vertically<ret>' ;;
       '[') k='<esc>: select-up<ret>' ;;
@@ -98,9 +98,9 @@ define-command -hidden text-object-vertical %{
 
 # hack to know in which "submode" we are
 # gGvV are not used in the context of this plugin
-declare-option -hidden str last_mode
+declare-option -hidden str objects_last_mode
 hook global NormalKey (g|G|v|V|<a-i>|<a-a>|\[|\]|\{|\}|<a-\[>|<a-\]>|<a-\{>|<a-\}>) %{
-  set-option global last_mode %val{hook_param}
+  set-option global objects_last_mode %val{hook_param}
 }
 
 # to add the mappings back if needed

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -83,12 +83,12 @@ define-command -hidden text-object-indented-paragraph %{
 define-command -hidden text-object-vertical %{
   evaluate-commands %sh{
     case "$kak_opt_objects_last_mode" in
-      '<a-i>') k='<esc>: select-vertically<ret>' ;;
-      '<a-a>') k='<a-i>w<esc>: select-vertically<ret>' ;;
-      '[') k='<esc>: select-up<ret>' ;;
-      ']') k='<esc>: select-down<ret>' ;;
-      '{') k='<a-i>w<esc>: select-up<ret>' ;;
-      '}') k='<a-i>w<esc>: select-down<ret>' ;;
+      '<a-i>') k='<esc>:<space>select-vertically<ret>' ;;
+      '<a-a>') k='<a-i>w<esc>:<space>select-vertically<ret>' ;;
+      '[') k='<esc>:<space>select-up<ret>' ;;
+      ']') k='<esc>:<space>select-down<ret>' ;;
+      '{') k='<a-i>w<esc>:<space>select-up<ret>' ;;
+      '}') k='<a-i>w<esc>:<space>select-down<ret>' ;;
     esac
     [ -n "$k" ] && echo "execute-keys $k"
   }

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -1,21 +1,21 @@
 # extended behaviors for pairs
-map global object ( '<esc>:text-object-block (<ret>'              -docstring 'prev parenthesis block'
-map global object ) '<esc>:text-object-block )<ret>'              -docstring 'next parenthesis block'
-map global object { '<esc>:text-object-block {<ret>'              -docstring 'prev braces block'
-map global object } '<esc>:text-object-block }<ret>'              -docstring 'next braces block'
-map global object [ '<esc>:text-object-block [<ret>'              -docstring 'prev brackets block'
-map global object ] '<esc>:text-object-block ]<ret>'              -docstring 'next brackets block'
-map global object <lt> '<esc>:text-object-block <lt><ret>'        -docstring 'prev angle block'
-map global object <gt> '<esc>:text-object-block <gt><ret>'        -docstring 'next angle block'
+map global object '('    '<esc>: text-object-block (<ret>'    -docstring 'prev parenthesis block'
+map global object ')'    '<esc>: text-object-block )<ret>'    -docstring 'next parenthesis block'
+map global object '{'    '<esc>: text-object-block {<ret>'    -docstring 'prev braces block'
+map global object '}'    '<esc>: text-object-block }<ret>'    -docstring 'next braces block'
+map global object '['    '<esc>: text-object-block [<ret>'    -docstring 'prev brackets block'
+map global object ']'    '<esc>: text-object-block ]<ret>'    -docstring 'next brackets block'
+map global object '<lt>' '<esc>: text-object-block <lt><ret>' -docstring 'prev angle block'
+map global object '<gt>' '<esc>: text-object-block <gt><ret>' -docstring 'next angle block'
 # additional text objects
-map global object x <esc>:text-object-line<ret>                   -docstring line
-map global object t <esc>:text-object-tag<ret>                    -docstring tag
-map global object <tab> <esc>:text-object-indented-paragraph<ret> -docstring 'indented paragraph'
+map global object 'x'     '<esc>: text-object-line<ret>'               -docstring 'line'
+map global object 't'     '<esc>: text-object-tag<ret>'                -docstring 'tag'
+map global object '<tab>' '<esc>: text-object-indented-paragraph<ret>' -docstring 'indented paragraph'
 # depends on occivink/vertical-selection.kak
-map global object v '<esc>:text-object-vertical<ret>'             -docstring 'vertical'
+map global object 'v' '<esc>: text-object-vertical<ret>' -docstring 'vertical'
 # alias to avoid shift
-map global object d '"'                                           -docstring 'double quote string'
-map global object o B                                             -docstring 'braces'
+map global object 'd' '"' -docstring 'double quote string'
+map global object 'o' 'B' -docstring 'braces'
 
 # see issue #9
 # first normal behavior, then fallback if it fails

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -12,7 +12,12 @@ map global object 'x'     '<esc>: text-object-line<ret>'               -docstrin
 map global object 't'     '<esc>: text-object-tag<ret>'                -docstring 'tag'
 map global object '<tab>' '<esc>: text-object-indented-paragraph<ret>' -docstring 'indented paragraph'
 # depends on occivink/vertical-selection.kak
-map global object 'v' '<esc>: text-object-vertical<ret>' -docstring 'vertical'
+map global object 'v' '<esc>: try %{
+                           text-object-vertical
+                       } catch %{
+                           echo -markup "{Information}occivink/vertical-selection.kak not installed"
+                       }
+                       <ret>' -docstring 'vertical'
 # alias to avoid shift
 map global object 'd' '"' -docstring 'double quote string'
 map global object 'o' 'B' -docstring 'braces'


### PR DESCRIPTION
Hello, your plugin is great, but...

First I've fixed showing all commands in command line history after usage of any mapping. This can be done by adding leading space before command after colon:
```kak
map global normal 'h' ': echo "no history for you"<ret>'
```
Entering command mode and pressing arrow up won't show this echo command. I find such entries annoying in my workflow, since I use some functions often but don't want to add those to mappings, and such entries are moving my commands upwards in history.

Then I've fixed error with trying to call for vertical-selection plugin when it's not installed, and replaced it with a meaningful warning.

After that I've added prefix to `last_mode` option, so it could represent it's plugin, and it wouldn't overlap if someone will decide to declare such option in either Kakoune, or another plugin. The name is bit lengthy but I think that safety is better.

And I've enclosed all mappings with single quotes unifying overall style, done some aligning and little formatting.