### PR TITLE
Extract user-mode and mappings

### DIFF
--- a/text-objects.kak
+++ b/text-objects.kak
@@ -130,6 +130,10 @@ hook global NormalKey (g|G|v|V|<a-i>|<a-a>|\[|\]|\{|\}|<a-\[>|<a-\]>|<a-\{>|<a-\
 
 try %{ declare-user-mode selectors }
 
+define-command -override selectors %{
+    enter-user-mode selectors
+}
+
 define-command -override -hidden selectors-init %{
   map global selectors 'a' '*%s<ret>' -docstring 'select all'
   map global selectors 'i' '<a-i>' -docstring 'select inside object <a-i>'

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -128,9 +128,25 @@ hook global NormalKey (g|G|v|V|<a-i>|<a-a>|\[|\]|\{|\}|<a-\[>|<a-\]>|<a-\{>|<a-\
   set-option global objects_last_mode %val{hook_param}
 }
 
+try %{ declare-user-mode selectors }
+
+define-command -override -hidden selectors-init %{
+  map global selectors 'a' '*%s<ret>' -docstring 'select all'
+  map global selectors 'i' '<a-i>' -docstring 'select inside object <a-i>'
+  map global selectors 'o' '<a-a>' -docstring 'select outside object <a-a>'
+
+  map global selectors 'j' '<a-[>' -docstring 'select inner object start <a-[>'
+  map global selectors 'k' '<a-]>' -docstring 'select inner object end <a-]>'
+  map global selectors 'J' '<a-{>' -docstring 'extend inner object start <a-{>'
+  map global selectors 'K' '<a-}>' -docstring 'extend inner object end <a-}>'
+
+  map global selectors 'h' '[' -docstring 'select object start ['
+  map global selectors 'l' ']' -docstring 'select object end ]'
+  map global selectors 'H' '{' -docstring 'extend object start {'
+  map global selectors 'L' '}' -docstring 'extend object end }'
+}
 # to add the mappings back if needed
 define-command -hidden text-object-map %{
-  try %{ declare-user-mode selectors }
   map global user s ': enter-user-mode selectors<ret>' -docstring 'selectors…'
 
   map global selectors 'a' '*%s<ret>' -docstring 'select all'
@@ -170,4 +186,4 @@ define-command -hidden text-object-unmap %{
 }
 
 # init
-# text-object-map
+selectors-init

--- a/text-objects.kak
+++ b/text-objects.kak
@@ -152,21 +152,6 @@ define-command -override -hidden selectors-init %{
 # to add the mappings back if needed
 define-command -hidden text-object-map %{
   map global user s ': enter-user-mode selectors<ret>' -docstring 'selectors…'
-
-  map global selectors 'a' '*%s<ret>' -docstring 'select all'
-
-  map global selectors 'i' '<a-i>' -docstring 'select inside object <a-i>'
-  map global selectors 'o' '<a-a>' -docstring 'select outside object <a-a>'
-
-  map global selectors 'j' '<a-[>' -docstring 'select inner object start <a-[>'
-  map global selectors 'k' '<a-]>' -docstring 'select inner object end <a-]>'
-  map global selectors 'J' '<a-{>' -docstring 'extend inner object start <a-{>'
-  map global selectors 'K' '<a-}>' -docstring 'extend inner object end <a-}>'
-
-  map global selectors 'h' '[' -docstring 'select object start ['
-  map global selectors 'l' ']' -docstring 'select object end ]'
-  map global selectors 'H' '{' -docstring 'extend object start {'
-  map global selectors 'L' '}' -docstring 'extend object end }'
 }
 
 # in rare scenarios when you need the original mappings


### PR DESCRIPTION
Right now, if the user wants access to the `selectors` user-mode they have to
use the `text-objects-map` command. This command also defines a `user s`
mapping that the user may or may not want to use for something else, this means
they get a conflict. Also if they want to map selectors mode to something else,
this leaves you with a polluted user menu.

This PR hopefully adds some flexibility to map the user mode to whatever they
want and also maintains backward compatability with existing configs.
